### PR TITLE
🚑 fix : 경매 생성 코드 수정

### DIFF
--- a/src/main/java/org/team1/keyduck/auction/service/AuctionService.java
+++ b/src/main/java/org/team1/keyduck/auction/service/AuctionService.java
@@ -35,7 +35,6 @@ public class AuctionService {
 
         Auction auction = Auction.builder()
                 .keyboard(findKeyboard)
-                .member(findKeyboard.getMember())
                 .title(requestDto.getTitle())
                 .startPrice(requestDto.getStartPrice())
                 .immediatePurchasePrice(requestDto.getImmediatePurchasePrice())


### PR DESCRIPTION
1. 경매 생성시 셀러의 아이디가 낙찰자 컬럼에 들어가는 것 확인 후
들어가지 않도록 코드 수정