### PR TITLE
🚑 fix : 경매 수정시 멤버 조회 로직 수정

### DIFF
--- a/src/main/java/org/team1/keyduck/auction/dto/response/AuctionUpdateResponseDto.java
+++ b/src/main/java/org/team1/keyduck/auction/dto/response/AuctionUpdateResponseDto.java
@@ -1,8 +1,8 @@
 package org.team1.keyduck.auction.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import lombok.Getter;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.team1.keyduck.auction.entity.Auction;
 
 @Getter
@@ -18,10 +18,10 @@ public class AuctionUpdateResponseDto {
 
     private final int biddingUnit;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime auctionStartDate;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime auctionEndDate;
 
     private AuctionUpdateResponseDto(

--- a/src/main/java/org/team1/keyduck/auction/service/AuctionService.java
+++ b/src/main/java/org/team1/keyduck/auction/service/AuctionService.java
@@ -78,7 +78,7 @@ public class AuctionService {
             throw new RuntimeException("진행중 이거나 종료된 경매는 수정할 수 없습니다.");
         }
 
-        if (!findAuction.getMember().getId().equals(sellerId)) {
+        if (!findAuction.getKeyboard().getMember().getId().equals(sellerId)) {
             throw new DataNotMatchException(ErrorCode.FORBIDDEN_ACCESS);
         }
         findAuction.updateAuction(requestDto);


### PR DESCRIPTION
- 경매 수정시 낙찰자의 아이디값을 얻어옴.
- ->낙찰자 아이디값은 최초에 null임
- ->그래서 키보드에 연결된 멤버의 아이디값을 얻어옴.

- 포트스맨 테스트시 LocalDateTime이 다른 DTO들과 다른 형식으로 응답하는 것을 발견
- 통일성을 위하여 @JsonFormat으로 변경