### PR TITLE
🚑 fix : 입찰 생성 관련 문제 쿼리 수정

### DIFF
--- a/src/main/java/org/team1/keyduck/bidding/repository/BiddingRepository.java
+++ b/src/main/java/org/team1/keyduck/bidding/repository/BiddingRepository.java
@@ -26,7 +26,6 @@ public interface BiddingRepository extends JpaRepository<Bidding, Long> {
     List<Bidding> findAllByAuctionId(Long auctionId);
 
 
-    @Query("SELECT b.price FROM Bidding b WHERE b.price ="
-            + "(SELECT MAX(b.price) FROM Bidding b WHERE b.auction.id = :auctionId AND b.member.id = :memberId)")
+    @Query("SELECT MAX(b.price) FROM Bidding b WHERE b.auction.id = :auctionId AND b.member.id = :memberId")
     Long findByMember_IdAndAuction_Id(Long memberId, Long auctionId);
 }


### PR DESCRIPTION
입찰 생성 관련해서 직전 금액이 여러행이 조회되어 입찰생성이 정상적으로 이루어지지 않던 문제 쿼리를 수정했습니다.