### PR TITLE
🚑 fix : AuctionRepository 메소드의 파라미터에 멤버아이디가 아니라 키보드 아이디가 들어가고 있던 문제 수정

### DIFF
--- a/src/main/java/org/team1/keyduck/keyboard/service/KeyboardService.java
+++ b/src/main/java/org/team1/keyduck/keyboard/service/KeyboardService.java
@@ -70,7 +70,7 @@ public class KeyboardService {
 
         // 경매 진행 중인 키보드 삭제 요청 -> 예외 발생
         if (auctionRepository.existsByKeyboard_Member_IdAndAuctionStatus(
-                keyboardId, AuctionStatus.IN_PROGRESS)) {
+                memberId, AuctionStatus.IN_PROGRESS)) {
             throw new OperationNotAllowedException(ErrorCode.AUCTION_NOT_MODIFIABLE_AND_DELETEABLE,
                     null);
         }
@@ -102,7 +102,7 @@ public class KeyboardService {
         }
 
         // 경매가 진행 중이거나 종료된 키보드 수정 요청 -> 예외 발생
-        if (!auctionRepository.existsByKeyboard_Member_IdAndAuctionStatus(keyboardId,
+        if (!auctionRepository.existsByKeyboard_Member_IdAndAuctionStatus(sellerId,
                 AuctionStatus.NOT_STARTED)) {
             throw new OperationNotAllowedException(ErrorCode.AUCTION_NOT_MODIFIABLE_AND_DELETEABLE,
                     null);


### PR DESCRIPTION
 AuctionRepository 메소드의 파라미터에 멤버아이디가 아니라 키보드 아이디가 들어가고 있던 문제 수정