### PR TITLE
🚑 fix : deploy.yml 세팅 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,16 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Gradle 캐싱
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: Linux-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            Linux-gradle-
-
       - name: Make .env file from GitHub Secrets
         run: |
           echo "${{ secrets.ENV_SECRET }}" > .env


### PR DESCRIPTION
test에서는 빌드를 github actions에서 진행해 gradle cache가 필요하다고 생각되나
머지 이후 deploy.yml이 돌아가는 과정에서는 github actions에서 빌드가 수행되지 않고, EC2에서 빌드가 진행되기에 gradle 캐싱이 필요없다고 판단되어 해당 과정 제거