### PR TITLE
🚑 fix : 멤버조회시 판매자와 구매자 모두

### DIFF
--- a/src/main/java/org/team1/keyduck/member/dto/response/MemberReadResponseDto.java
+++ b/src/main/java/org/team1/keyduck/member/dto/response/MemberReadResponseDto.java
@@ -18,16 +18,16 @@ public class MemberReadResponseDto {
 
     private final Address address;
 
-    private final Long paymentDeposit;
+    private final Long myPoint;
 
     private MemberReadResponseDto(Long id, String name, String email, MemberRole memberRole,
-            Address address, Long paymentDeposit) {
+            Address address, Long myPoint) {
         this.id = id;
         this.name = name;
         this.email = email;
         this.memberRole = memberRole;
         this.address = address;
-        this.paymentDeposit = paymentDeposit;
+        this.myPoint = myPoint;
     }
 
     public static MemberReadResponseDto of(Member member, Long deposit) {

--- a/src/main/java/org/team1/keyduck/member/service/MemberService.java
+++ b/src/main/java/org/team1/keyduck/member/service/MemberService.java
@@ -21,6 +21,7 @@ import org.team1.keyduck.member.entity.Member;
 import org.team1.keyduck.member.entity.MemberRole;
 import org.team1.keyduck.member.repository.MemberRepository;
 import org.team1.keyduck.payment.repository.PaymentDepositRepository;
+import org.team1.keyduck.payment.repository.SaleProfitRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +31,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final AuctionRepository auctionRepository;
     private final PaymentDepositRepository paymentDepositRepository;
+    private final SaleProfitRepository saleProfitRepository;
 
     private final JwtBlacklistService jwtBlacklistService;
     private final CommonService commonService;
@@ -89,6 +91,13 @@ public class MemberService {
     public MemberReadResponseDto getMember(Long id) {
         Member member = memberRepository.findById(id).orElseThrow(() -> new DataNotFoundException(
                 ErrorCode.NOT_FOUND_MEMBER, ErrorMessageParameter.MEMBER));
+
+        if (member.getMemberRole().equals(MemberRole.SELLER)) {
+
+            Long sellerPoint = saleProfitRepository.findSellerPointByMember_Id(id).orElse(0L);
+
+            return MemberReadResponseDto.of(member, sellerPoint);
+        }
 
         Long paymentDeposit = paymentDepositRepository.findPaymentDepositAmountMember_Id(id)
                 .orElse(0L);

--- a/src/main/java/org/team1/keyduck/member/service/MemberService.java
+++ b/src/main/java/org/team1/keyduck/member/service/MemberService.java
@@ -93,15 +93,12 @@ public class MemberService {
                 ErrorCode.NOT_FOUND_MEMBER, ErrorMessageParameter.MEMBER));
 
         if (member.getMemberRole().equals(MemberRole.SELLER)) {
-
             Long sellerPoint = saleProfitRepository.findSellerPointByMember_Id(id).orElse(0L);
-
             return MemberReadResponseDto.of(member, sellerPoint);
+        } else {
+            Long paymentDeposit = paymentDepositRepository.findPaymentDepositAmountMember_Id(id)
+                    .orElse(0L);
+            return MemberReadResponseDto.of(member, paymentDeposit);
         }
-
-        Long paymentDeposit = paymentDepositRepository.findPaymentDepositAmountMember_Id(id)
-                .orElse(0L);
-
-        return MemberReadResponseDto.of(member, paymentDeposit);
     }
 }

--- a/src/main/java/org/team1/keyduck/payment/repository/SaleProfitRepository.java
+++ b/src/main/java/org/team1/keyduck/payment/repository/SaleProfitRepository.java
@@ -1,8 +1,13 @@
 package org.team1.keyduck.payment.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.team1.keyduck.payment.entity.SaleProfit;
 
 public interface SaleProfitRepository extends JpaRepository<SaleProfit, Long> {
+
+    @Query("SELECT SUM (p.winningPrice) FROM SaleProfit p WHERE p.member.id = :memberId")
+    Optional<Long> findSellerPointByMember_Id(Long memberId);
 
 }


### PR DESCRIPTION
자신의 포인트를 볼 수 있도록 로직 변경
- 기존에 멤버조회시 구매자는 자신이 보유한 포인트를 확인할 수 있지만,
판매자는 본인의 판매 수익금을 볼 수 없음에도 Response에 paymentDeposit이 출력되었음.
로직을 수정하여 판매자는 본인의 수익금을
구매자는 본인의 포인트를 볼 수 있도록 변경